### PR TITLE
Gather events based upon complete_time instead of run_time

### DIFF
--- a/KCLS/utility-scripts/xml-notices/create-notice-file.pl
+++ b/KCLS/utility-scripts/xml-notices/create-notice-file.pl
@@ -289,7 +289,7 @@ sub collect_events {
             '+atev' => {
                 event_def => $event_def,
                 state => 'complete',
-                run_time => {'between' => [$start_date, $end_date]}
+                complete_time => {'between' => [$start_date, $end_date]}
             }
         },
         order_by => [


### PR DESCRIPTION
Solving a situation where large jobs can take longer than the window of time that was passed into the code. Thereby omitting some AT outputs that should be included.